### PR TITLE
Just use libgit2sharp (and latest preview)

### DIFF
--- a/src/Konmaripo.Web/Konmaripo.Web.csproj
+++ b/src/Konmaripo.Web/Konmaripo.Web.csproj
@@ -10,8 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Functional.Maybe" Version="2.0.20" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
-    <PackageReference Include="libgit2sharp" Version="0.26.2" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.306" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />


### PR DESCRIPTION
Resolves #200.

Also removes the explicit dependency on the NativeBinaries packages, because the package brings in the exact version it needs as a transitive dependency.