### PR TITLE
Greatly simplify fetching of branches

### DIFF
--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -50,6 +50,7 @@ namespace Konmaripo.Web.Services
             var pathToRepoGitFile = LibGit2Sharp.Repository.Clone(url, clonePath, options);
 
             // This ensures all branches and tags get fetched as well.
+            // ReSharper disable once RedundantNameQualifier -- so we can quickly tell between Octokit and Libgit2sharp
             using (var repo = new LibGit2Sharp.Repository(pathToRepoGitFile))
             {
                 repo.Network.Fetch("origin", new List<string>(){ "+refs/*:refs/*" }, fetchOptions);

--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Konmaripo.Web.Models;
 using LibGit2Sharp;
 using Microsoft.Extensions.Options;

--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -49,7 +49,6 @@ namespace Konmaripo.Web.Services
                 // ReSharper enable InconsistentNaming
             };
 
-            //var destinationArchiveFileName = Path.Combine(START_PATH, $"{repoName}.zip");
             var clonePath = Path.Combine(START_PATH, repoName);
 
             // TODO: Make async

--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -47,6 +47,7 @@ namespace Konmaripo.Web.Services
             var clonePath = Path.Combine(START_PATH, repoName);
 
             // TODO: Make async
+            // ReSharper disable once RedundantNameQualifier -- so we can quickly tell between Octokit and Libgit2sharp
             var pathToRepoGitFile = LibGit2Sharp.Repository.Clone(url, clonePath, options);
 
             // This ensures all branches and tags get fetched as well.

--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -34,7 +34,7 @@ namespace Konmaripo.Web.Services
             var fetchOptions = new FetchOptions()
             {
                 TagFetchMode = TagFetchMode.All,
-                CredentialsProvider = (_url, _user, _cred) => creds,
+                CredentialsProvider = (_, _, _) => creds,
                 Prune = false
             };
 
@@ -43,10 +43,8 @@ namespace Konmaripo.Web.Services
                 Checkout = true,
                 IsBare = false,
                 RecurseSubmodules = true,
-                // ReSharper disable InconsistentNaming
-                CredentialsProvider = (_url, _user, _cred) => creds,
+                CredentialsProvider = (_, _, _) => creds,
                 FetchOptions = fetchOptions
-                // ReSharper enable InconsistentNaming
             };
 
             var clonePath = Path.Combine(START_PATH, repoName);

--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -61,11 +61,5 @@ namespace Konmaripo.Web.Services
             var pathToFullRepo = pathToRepoGitFile.Replace(".git/", ""); // Directory.GetParent didn't work for this, maybe due to the period in the directory name.
             return new RepositoryPath(pathToFullRepo);
         }
-
-        private string GenerateLocalBranchName(Branch x)
-        {
-            return x.FriendlyName.Replace($"{REMOTE_NAME}/", string.Empty);
-        }
-
     }
 }

--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -10,7 +10,7 @@ namespace Konmaripo.Web.Services
     {
         private readonly string _githubOrgName;
         private readonly string _accessToken;
-        const string START_PATH = "./Data"; // TODO: Extract to config
+        private const string START_PATH = "./Data"; // TODO: Extract to config
 
         public RepositoryArchiver(IOptions<GitHubSettings> githubSettings)
         {

--- a/src/Konmaripo.Web/Services/RepositoryArchiver.cs
+++ b/src/Konmaripo.Web/Services/RepositoryArchiver.cs
@@ -12,7 +12,6 @@ namespace Konmaripo.Web.Services
     {
         private readonly string _githubOrgName;
         private readonly string _accessToken;
-        const string REMOTE_NAME = "origin"; // hard-coded since this will be the default when cloned from GitHub.
         const string START_PATH = "./Data"; // TODO: Extract to config
 
         public RepositoryArchiver(IOptions<GitHubSettings> githubSettings)

--- a/src/Konmaripo.sln.DotSettings
+++ b/src/Konmaripo.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=API/@EntryIndexedValue">API</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AA_BB" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=batcher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=blahblah/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=blahblahblah/@EntryIndexedValue">True</s:Boolean>

--- a/src/Konmaripo.sln.DotSettings
+++ b/src/Konmaripo.sln.DotSettings
@@ -8,4 +8,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hacky/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HSTS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Konmaripo/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Octokit/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sunsetting/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Resolves #202.

Turns out, I was doing things waaaaay harder than I needed to. 

Previously, I was getting the individual remote branches, then generating a local name for them, and then manually trying to set up a tracking branch for each. 

Nooooone of that is necessary.

When I clone the repo, the `origin` remote is already set up.

I can fetch all of the remote branches with the ref spec of `"+refs/*:refs/*"` which tells git to fetch everything.

Since we know the local branches won't exist when we pull it, there won't be any conflicts or stale information.

Killing code -- my favorite thing!

Tested locally with the `ithelpbot` repo -- it pulled all the branches and I was able to switch between them locally which is exactly what we want.